### PR TITLE
Display similar news dynamically and refactor view layout

### DIFF
--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -22,6 +22,7 @@ class NewsController < ApplicationController
 
   def show
     @news = News.find(params[:id])
+    @similar_news = News.where(type_of_news: @news.type_of_news).where.not(id: @news.id).limit(5)
   end
 
   def new

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -15,14 +15,21 @@
     <p class="text-2xl font-semibold p-24"><%= @news.header_news %></p>
     <div class="pl-24 pr-24">
       <p class="text-base font-light mb-4"><%= @news.content %></p>
-      <article class="flex justify-start mt-4">
+    </div>
+
+
+      <article class="flex justify-start mt-4 pl-24 pr-24">
         <!-- Card 2 -->
+        <% @similar_news.each do |similar_news| %>
         <div class="bg-black shadow-lg overflow-hidden w-1/4 mr-2">
           <img
             src="../assets/new_team.png"
             alt="New Kit"
             class="w-full h-48 object-cover rounded"
             />
+
+          <%= image_tag(similar_news.image, class: "rounded w-full") %>
+
           <div class="flex">
             <!-- Text Section -->
             <div class="p-4 text-center">
@@ -44,64 +51,7 @@
             </div>
           </div>
         </div>
-
-        <!-- Card 3 -->
-        <div class="bg-black shadow-lg overflow-hidden w-1/4 mr-2">
-          <img
-            src="../assets/new_team.png"
-            alt="New Kit"
-            class="w-full h-48 object-cover rounded"
-            />
-          <div class="flex">
-            <!-- Text Section -->
-            <div class="p-4 text-center">
-              <p class="text-white mt-2">
-                Spain men in basketball and football<br />action
-              </p>
-              <a
-                href="#"
-                class="mt-4 inline-flex text-xs items-center text-white font-semibold"
-              >
-                <span class="ml-1">&rarr;</span> Club
-              </a>
-              <a
-                href="#"
-                class="mt-4 inline-flex text-xs items-center text-white font-semibold"
-              >
-                <span class="ml-1">&rarr;</span> 3 hrs ago
-              </a>
-            </div>
-          </div>
-        </div>
-
-        <!-- Card 4 -->
-        <div class="bg-black shadow-lg overflow-hidden w-1/4 mr-2">
-          <img
-            src="../assets/new_team.png"
-            alt="New Kit"
-            class="w-full h-48 object-cover rounded"
-            />
-          <div class="flex">
-            <!-- Text Section -->
-            <div class="p-4 text-center">
-              <p class="text-white mt-2">
-                Spain men in basketball and football<br />action
-              </p>
-              <a
-                href="#"
-                class="mt-4 inline-flex text-xs items-center text-white font-semibold"
-              >
-                <span class="ml-1">&rarr;</span> Club
-              </a>
-              <a
-                href="#"
-                class="mt-4 inline-flex text-xs items-center text-white font-semibold"
-              >
-                <span class="ml-1">&rarr;</span> 3 hrs ago
-              </a>
-            </div>
-          </div>
-        </div>
+          <% end %>
       </article>
     </div>
 
@@ -118,7 +68,7 @@
       </div>
     <% end %>
   </div>
-</div>
+
 
 
 


### PR DESCRIPTION
Implemented dynamic rendering of similar news in the view using a database query that finds related news items based on type. Removed hardcoded cards for better scalability and cleaned up the layout structure for consistency.
This pull request includes changes to the `NewsController` and the `news` view to display similar news articles on the news show page. The most important changes are:

**Controller Changes:**
* [`app/controllers/news_controller.rb`](diffhunk://#diff-94d1bfe7692f0a221f1b1b25e2a58727a0e3eb61e52760f37087f2220867ea2fR25): Added a query to fetch similar news articles based on the type of news and excluding the current news article. This query limits the results to 5 similar articles.

**View Changes:**
* [`app/views/news/show.html.erb`](diffhunk://#diff-ff7bcff9f6d9e50eb95fa219808e093d609787bd173f6e9c055e9a9564cccf28L18-R36): Removed hardcoded news cards and replaced them with a loop that dynamically generates news cards for each similar news article fetched from the controller. This includes displaying the image and other details of the similar news articles. [[1]](diffhunk://#diff-ff7bcff9f6d9e50eb95fa219808e093d609787bd173f6e9c055e9a9564cccf28L18-R36) [[2]](diffhunk://#diff-ff7bcff9f6d9e50eb95fa219808e093d609787bd173f6e9c055e9a9564cccf28R54) [[3]](diffhunk://#diff-ff7bcff9f6d9e50eb95fa219808e093d609787bd173f6e9c055e9a9564cccf28L121-R71)