### PR TITLE
Use `image_tag` helper for logo rendering in views.

### DIFF
--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -8,10 +8,15 @@ class NewsController < ApplicationController
     #
     @pagy, @news = if params[:query].present?
                      pagy_countless(
-                       News.where('type_of_news ILIKE ?', "%#{params[:query]}%").includes(image_attachment: :blob).order('created_at DESC'), items: 8
+                       News.where('type_of_news ILIKE ?', "%#{params[:query]}%")
+                           .includes(image_attachment: :blob)
+                           .order('created_at DESC'), items: 8
                      )
                    else
-                     pagy_countless(News.includes(image_attachment: :blob).all.order('created_at DESC'), items: 8)
+                     pagy_countless(
+                       News.includes(image_attachment: :blob)
+                           .order('created_at DESC'), items: 8
+                     )
                    end
     respond_to do |format|
       format.html
@@ -21,8 +26,8 @@ class NewsController < ApplicationController
   end
 
   def show
-    @news = News.find(params[:id])
-    @similar_news = News.where(type_of_news: @news.type_of_news).where.not(id: @news.id).limit(5)
+    @news = News.includes(image_attachment: :blob).find(params[:id])
+    @similar_news = News.includes(image_attachment: :blob).where(type_of_news: @news.type_of_news).where.not(id: @news.id).limit(5)
   end
 
   def new

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -20,37 +20,33 @@
 
       <article class="flex justify-start mt-4 pl-24 pr-24">
         <!-- Card 2 -->
-        <% @similar_news.each do |similar_news| %>
+        <% @similar_news.limit(4).each do |similar_news| %>
         <div class="bg-black shadow-lg overflow-hidden w-1/4 mr-2">
-          <img
-            src="../assets/new_team.png"
-            alt="New Kit"
-            class="w-full h-48 object-cover rounded"
-            />
+          <%= link_to news_path(similar_news)  do%>
+              <%= image_tag(similar_news.image, class: "rounded w-full") %>
 
-          <%= image_tag(similar_news.image, class: "rounded w-full") %>
-
-          <div class="flex">
-            <!-- Text Section -->
-            <div class="p-4 text-center">
-              <p class="text-[#fff] mt-2">
-                Spain men in basketball and football<br />action
-              </p>
-              <a
-                href="#"
-                class="mt-4 inline-flex text-xs items-center text-white font-semibold"
-              >
-                <span class="ml-1">&rarr;</span> Club
-              </a>
-              <a
-                href="#"
-                class="mt-4 inline-flex text-xs items-center text-white font-semibold"
-              >
-                <span class="ml-1">&rarr;</span> 3 hrs ago
-              </a>
+              <div class="flex">
+                <!-- Text Section -->
+                <div class="p-4 text-center">
+                  <p class="text-[#fff] mt-2">
+                    <%= truncate(similar_news.header_news, length: 30) %>
+                  </p>
+                  <a
+                    href="#"
+                    class="mt-4 inline-flex text-xs items-center text-white font-semibold"
+                  >
+                    <span class="ml-1">&rarr;</span> <%= similar_news.type_of_news %>
+                  </a>
+                  <a
+                    href="#"
+                    class="mt-4 inline-flex text-xs items-center text-white font-semibold"
+                  >
+                    <span class="ml-1">&rarr;</span> <%= time_ago_in_words(similar_news.created_at) %> ago
+                  </a>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
+            <% end %>
           <% end %>
       </article>
     </div>


### PR DESCRIPTION
This pull request includes several changes to the `NewsController` and the `news/show.html.erb` view to improve the handling and display of news items and their associated images. The most important changes are summarized below:

### Controller Improvements:

* [`app/controllers/news_controller.rb`](diffhunk://#diff-94d1bfe7692f0a221f1b1b25e2a58727a0e3eb61e52760f37087f2220867ea2fL11-R19): Refactored the `index` method to improve readability by formatting the query conditions and `pagy_countless` calls.
* [`app/controllers/news_controller.rb`](diffhunk://#diff-94d1bfe7692f0a221f1b1b25e2a58727a0e3eb61e52760f37087f2220867ea2fL24-R30): Enhanced the `show` method to include image attachments when fetching news items and similar news items.

### View Enhancements:

* [`app/views/news/show.html.erb`](diffhunk://#diff-ff7bcff9f6d9e50eb95fa219808e093d609787bd173f6e9c055e9a9564cccf28L23-R50): Limited the number of similar news items displayed to 4 and updated the display to include image links, truncated headers, and dynamic type and time information.Replaced static `<img>` tags with Rails `image_tag` helper in `_table_display.html.erb` and `_schedule.html.erb` partials for better asset management and consistency. Updated alt attributes for improved accessibility.