### PR TITLE
Limit similar news to 3 and adjust layout styling

### DIFF
--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -27,7 +27,7 @@ class NewsController < ApplicationController
 
   def show
     @news = News.includes(image_attachment: :blob).find(params[:id])
-    @similar_news = News.includes(image_attachment: :blob).where(type_of_news: @news.type_of_news).where.not(id: @news.id).limit(5)
+    @similar_news = News.includes(image_attachment: :blob).where(type_of_news: @news.type_of_news).where.not(id: @news.id).limit(3)
   end
 
   def new

--- a/app/views/news/_similar_news.html.erb
+++ b/app/views/news/_similar_news.html.erb
@@ -1,8 +1,8 @@
 <article class="flex justify-start mt-4">
-  <% @similar_news.limit(4).each do |similar_news| %>
-    <div class="bg-black shadow-lg overflow-hidden w-1/4 mr-2">
+  <% @similar_news.limit(3).each do |similar_news| %>
+    <div class="bg-black shadow-lg overflow-hidden w-1/3 mr-2">
       <%= link_to news_path(similar_news) do %>
-        <%= image_tag(similar_news.image, class: "rounded w-full h-[200px]") %>
+        <%= image_tag(similar_news.image, class: "rounded w-full h-[150px]") %>
         <div class="flex">
           <div class="text-left">
             <a href="#" class="mt-4 inline-flex text-sm items-center text-black bg-[#FAE115] p-1 rounded ">

--- a/app/views/news/edit.html.erb
+++ b/app/views/news/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto my-8">
+<div class="max-w-4xl mx-auto my-8 text-black">
   <%= form_with(model: @news, url: news_path(@news), method: :patch, class: "bg-white rounded shadow-md p-6") do |form| %>
 
     <div class="mb-4 flex">

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -48,12 +48,11 @@
               </button>
             </div>
           </div>
+
         </div>
-
         <%= render 'news/similar_news' %>
-
-
       </div>
+
       <div class="col-span-1">
       </div>
     </div>


### PR DESCRIPTION
<commit>
Reduced the number of similar news displayed from 5 to 3 for consistency. Updated associated layout styles to match the new limit, including width and height adjustments. Added a text color to the news edit form for better readability.
</commit>