### PR TITLE
Make match date and time fields mandatory

### DIFF
--- a/app/views/opponent/edit.html.erb
+++ b/app/views/opponent/edit.html.erb
@@ -12,8 +12,8 @@
       </p>
 
       <div class="flex  justify-between">
-        <%= f.date_field :match_date, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] border-black focus:outline-none" ,placeholder: "Match Date" %>
-        <%= f.time_field :match_time, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] border-black focus:outline-none" ,placeholder: "Match Time" %>
+        <%= f.date_field :match_date, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] border-black focus:outline-none" ,placeholder: "Match Date" , required: true %>
+        <%= f.time_field :match_time, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] border-black focus:outline-none" ,placeholder: "Match Time" , required: true %>
       </div>
       <div class="flex  justify-between">
 

--- a/app/views/opponent/index.html.erb
+++ b/app/views/opponent/index.html.erb
@@ -64,7 +64,7 @@
   </div>
 
   <div id="Schedule" class="tabcontent active  ">
-    <%= render 'opponent/schedule' %>
+    <%#= render 'opponent/schedule' %>
   </div>
 
   <div id="Result" class="tabcontent">

--- a/app/views/opponent/new.html.erb
+++ b/app/views/opponent/new.html.erb
@@ -13,8 +13,8 @@
       </p>
 
       <div class="flex  justify-between">
-        <%= f.date_field :match_date, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black text-black border-black focus:outline-none" ,placeholder: "Match Date" %>
-        <%= f.time_field :match_time, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Match Time" %>
+        <%= f.date_field :match_date, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black text-black border-black focus:outline-none" ,placeholder: "Match Date" , required: true %>
+        <%= f.time_field :match_time, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Match Time", required: true %>
       </div>
       <div class="flex  justify-between">
 


### PR DESCRIPTION
Added the `required` attribute to `match_date` and `match_time` fields in `edit` and `new` views to enforce input validation. Also commented out the `schedule` partial rendering in the `index` view for future review.

This pull request includes changes to the `opponent` views, focusing on improving form validation and temporarily disabling a schedule rendering.

Form validation improvements:

* [`app/views/opponent/edit.html.erb`](diffhunk://#diff-fe60c148d695737ca04030424771fb695849363f68abe3b81b477fca0773ac65L15-R16): Added the `required` attribute to the `match_date` and `match_time` fields to ensure they are mandatory.
* [`app/views/opponent/new.html.erb`](diffhunk://#diff-1e54fe467e1f1bd40954f853798e9b9d6432b9b3b86499cbdbbfd0044ed6b33bL16-R17): Added the `required` attribute to the `match_date` and `match_time` fields to ensure they are mandatory.

Temporary schedule rendering change:

* [`app/views/opponent/index.html.erb`](diffhunk://#diff-cbd99f9da0f29b41578547979976e26ad165e4e1c5cd5beb84799acb6bb1e4d1L67-R67): Commented out the rendering of the opponent schedule partial.