### PR TITLE
Revert "Limit similar news to 3 and adjust layout styling"

### DIFF
--- a/.idea/mseals.iml
+++ b/.idea/mseals.iml
@@ -47,6 +47,7 @@
     <orderEntry type="library" scope="PROVIDED" name="ast (v2.4.2, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="audited (v5.8.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="aws_cf_signer (v0.1.3, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="base64 (v0.2.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="bcrypt (v3.1.20, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="bigdecimal (v3.1.8, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="bindex (v0.8.1, rbenv: 3.3.5) [gem]" level="application" />
@@ -99,6 +100,7 @@
     <orderEntry type="library" scope="PROVIDED" name="minitest (v5.25.4, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="motor-admin (v0.4.31, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="msgpack (v1.7.5, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="mutex_m (v0.2.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="net-imap (v0.5.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="net-pop (v0.1.2, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="net-protocol (v0.2.2, rbenv: 3.3.5) [gem]" level="application" />
@@ -107,6 +109,7 @@
     <orderEntry type="library" scope="PROVIDED" name="nio4r (v2.7.4, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="nokogiri (v1.16.8, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="orm_adapter (v0.5.0, rbenv: 3.3.5) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="ostruct (v0.6.1, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="pagy (v6.5.0, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="parallel (v1.26.3, rbenv: 3.3.5) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="parser (v3.3.6.0, rbenv: 3.3.5) [gem]" level="application" />
@@ -676,43 +679,42 @@
       </RakeTaskImpl>
     </option>
   </component>
-  <component name="RakeTasksCache-v2" failedReloadsCounter="1">
-    <option name="failedReloadsCounter" value="1" />
+  <component name="RakeTasksCache-v2">
     <option name="myRootTask">
       <RakeTaskImpl id="rake">
         <subtasks>
-          <RakeTaskImpl description="List versions of all Rails frameworks and the environment" fullCommand="about" id="about" />
+          <RakeTaskImpl description="" fullCommand="about" id="about" />
           <RakeTaskImpl id="action_mailbox">
             <subtasks>
               <RakeTaskImpl id="ingress">
                 <subtasks>
-                  <RakeTaskImpl description="Relay an inbound email from Exim to Action Mailbox (URL and INGRESS_PASSWORD required)" fullCommand="action_mailbox:ingress:exim" id="exim" />
-                  <RakeTaskImpl description="Relay an inbound email from Postfix to Action Mailbox (URL and INGRESS_PASSWORD required)" fullCommand="action_mailbox:ingress:postfix" id="postfix" />
-                  <RakeTaskImpl description="Relay an inbound email from Qmail to Action Mailbox (URL and INGRESS_PASSWORD required)" fullCommand="action_mailbox:ingress:qmail" id="qmail" />
                   <RakeTaskImpl description="" fullCommand="action_mailbox:ingress:environment" id="environment" />
+                  <RakeTaskImpl description="" fullCommand="action_mailbox:ingress:exim" id="exim" />
+                  <RakeTaskImpl description="" fullCommand="action_mailbox:ingress:postfix" id="postfix" />
+                  <RakeTaskImpl description="" fullCommand="action_mailbox:ingress:qmail" id="qmail" />
                 </subtasks>
               </RakeTaskImpl>
-              <RakeTaskImpl description="Installs Action Mailbox and its dependencies" fullCommand="action_mailbox:install" id="install" />
+              <RakeTaskImpl description="" fullCommand="action_mailbox:install" id="install" />
               <RakeTaskImpl id="install">
                 <subtasks>
-                  <RakeTaskImpl description="Copy migrations from action_mailbox to application" fullCommand="action_mailbox:install:migrations" id="migrations" />
+                  <RakeTaskImpl description="" fullCommand="action_mailbox:install:migrations" id="migrations" />
                 </subtasks>
               </RakeTaskImpl>
             </subtasks>
           </RakeTaskImpl>
           <RakeTaskImpl id="action_text">
             <subtasks>
-              <RakeTaskImpl description="Copy over the migration, stylesheet, and JavaScript files" fullCommand="action_text:install" id="install" />
+              <RakeTaskImpl description="" fullCommand="action_text:install" id="install" />
               <RakeTaskImpl id="install">
                 <subtasks>
-                  <RakeTaskImpl description="Copy migrations from action_text to application" fullCommand="action_text:install:migrations" id="migrations" />
+                  <RakeTaskImpl description="" fullCommand="action_text:install:migrations" id="migrations" />
                 </subtasks>
               </RakeTaskImpl>
             </subtasks>
           </RakeTaskImpl>
           <RakeTaskImpl id="active_storage">
             <subtasks>
-              <RakeTaskImpl description="Copy over the migration needed to the application" fullCommand="active_storage:install" id="install" />
+              <RakeTaskImpl description="" fullCommand="active_storage:install" id="install" />
               <RakeTaskImpl id="install">
                 <subtasks>
                   <RakeTaskImpl description="" fullCommand="active_storage:install:migrations" id="migrations" />
@@ -721,17 +723,17 @@
               <RakeTaskImpl description="" fullCommand="active_storage:update" id="update" />
             </subtasks>
           </RakeTaskImpl>
-          <RakeTaskImpl description="Add schema information (as comments) to model and fixture files" fullCommand="annotate_models" id="annotate_models" />
-          <RakeTaskImpl description="Adds the route map to routes.rb" fullCommand="annotate_routes" id="annotate_routes" />
+          <RakeTaskImpl description="" fullCommand="annotate_models" id="annotate_models" />
+          <RakeTaskImpl description="" fullCommand="annotate_routes" id="annotate_routes" />
           <RakeTaskImpl id="app">
             <subtasks>
-              <RakeTaskImpl description="Applies the template supplied by LOCATION=(/path/to/template) or URL" fullCommand="app:template" id="template" />
-              <RakeTaskImpl description="Update configs and some other initially generated files (or use just update:configs or update:bin)" fullCommand="app:update" id="update" />
+              <RakeTaskImpl description="" fullCommand="app:template" id="template" />
               <RakeTaskImpl id="templates">
                 <subtasks>
                   <RakeTaskImpl description="" fullCommand="app:templates:copy" id="copy" />
                 </subtasks>
               </RakeTaskImpl>
+              <RakeTaskImpl description="" fullCommand="app:update" id="update" />
               <RakeTaskImpl id="update">
                 <subtasks>
                   <RakeTaskImpl description="" fullCommand="app:update:active_storage" id="active_storage" />
@@ -745,107 +747,105 @@
           </RakeTaskImpl>
           <RakeTaskImpl id="assets">
             <subtasks>
-              <RakeTaskImpl description="Remove old compiled assets" fullCommand="assets:clean[keep]" id="clean[keep]" />
-              <RakeTaskImpl description="Remove compiled assets" fullCommand="assets:clobber" id="clobber" />
-              <RakeTaskImpl description="Load asset compile environment" fullCommand="assets:environment" id="environment" />
-              <RakeTaskImpl description="Compile all the assets named in config.assets.precompile" fullCommand="assets:precompile" id="precompile" />
               <RakeTaskImpl description="" fullCommand="assets:clean" id="clean" />
+              <RakeTaskImpl description="" fullCommand="assets:clobber" id="clobber" />
+              <RakeTaskImpl description="" fullCommand="assets:environment" id="environment" />
+              <RakeTaskImpl description="" fullCommand="assets:precompile" id="precompile" />
             </subtasks>
           </RakeTaskImpl>
           <RakeTaskImpl id="cache_digests">
             <subtasks>
-              <RakeTaskImpl description="Lookup first-level dependencies for TEMPLATE (like messages/show or comments/_comment.html)" fullCommand="cache_digests:dependencies" id="dependencies" />
-              <RakeTaskImpl description="Lookup nested dependencies for TEMPLATE (like messages/show or comments/_comment.html)" fullCommand="cache_digests:nested_dependencies" id="nested_dependencies" />
+              <RakeTaskImpl description="" fullCommand="cache_digests:dependencies" id="dependencies" />
+              <RakeTaskImpl description="" fullCommand="cache_digests:nested_dependencies" id="nested_dependencies" />
             </subtasks>
           </RakeTaskImpl>
           <RakeTaskImpl id="cloudinary">
             <subtasks>
-              <RakeTaskImpl description="Fetch the latest JavaScript library files and create the JavaScript index files" fullCommand="cloudinary:fetch_assets" id="fetch_assets" />
-              <RakeTaskImpl description="Sync static resources with cloudinary" fullCommand="cloudinary:sync_static" id="sync_static" />
+              <RakeTaskImpl description="" fullCommand="cloudinary:fetch_assets" id="fetch_assets" />
+              <RakeTaskImpl description="" fullCommand="cloudinary:sync_static" id="sync_static" />
             </subtasks>
           </RakeTaskImpl>
           <RakeTaskImpl id="db">
             <subtasks>
-              <RakeTaskImpl description="Creates the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:create:all to create all databases in the config). Without RAILS_ENV or when RAILS_ENV is development, it defaults to creating the development and test databases, except when DATABASE_URL is present" fullCommand="db:create" id="create" />
-              <RakeTaskImpl description="Drops the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:drop:all to drop all databases in the config). Without RAILS_ENV or when RAILS_ENV is development, it defaults to dropping the development and test databases, except when DATABASE_URL is present" fullCommand="db:drop" id="drop" />
-              <RakeTaskImpl id="encryption">
-                <subtasks>
-                  <RakeTaskImpl description="Generate a set of keys for configuring Active Record encryption in a given environment" fullCommand="db:encryption:init" id="init" />
-                </subtasks>
-              </RakeTaskImpl>
-              <RakeTaskImpl id="environment">
-                <subtasks>
-                  <RakeTaskImpl description="Set the environment value for the database" fullCommand="db:environment:set" id="set" />
-                </subtasks>
-              </RakeTaskImpl>
-              <RakeTaskImpl id="fixtures">
-                <subtasks>
-                  <RakeTaskImpl description="Loads fixtures into the current environment's database" fullCommand="db:fixtures:load" id="load" />
-                  <RakeTaskImpl description="" fullCommand="db:fixtures:identify" id="identify" />
-                </subtasks>
-              </RakeTaskImpl>
-              <RakeTaskImpl description="Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog)" fullCommand="db:migrate" id="migrate" />
-              <RakeTaskImpl id="migrate">
-                <subtasks>
-                  <RakeTaskImpl description="Runs the &quot;down&quot; for a given migration VERSION" fullCommand="db:migrate:down" id="down" />
-                  <RakeTaskImpl description="Rolls back the database one migration and re-migrates up (options: STEP=x, VERSION=x)" fullCommand="db:migrate:redo" id="redo" />
-                  <RakeTaskImpl description="Display status of migrations" fullCommand="db:migrate:status" id="status" />
-                  <RakeTaskImpl description="Runs the &quot;up&quot; for a given migration VERSION" fullCommand="db:migrate:up" id="up" />
-                  <RakeTaskImpl description="" fullCommand="db:migrate:reset" id="reset" />
-                </subtasks>
-              </RakeTaskImpl>
-              <RakeTaskImpl description="Runs setup if database does not exist, or runs migrations if it does" fullCommand="db:prepare" id="prepare" />
-              <RakeTaskImpl description="Drops and recreates all databases from their schema for the current environment and loads the seeds" fullCommand="db:reset" id="reset" />
-              <RakeTaskImpl description="Rolls the schema back to the previous version (specify steps w/ STEP=n)" fullCommand="db:rollback" id="rollback" />
-              <RakeTaskImpl id="schema">
-                <subtasks>
-                  <RakeTaskImpl id="cache">
-                    <subtasks>
-                      <RakeTaskImpl description="Clears a db/schema_cache.yml file" fullCommand="db:schema:cache:clear" id="clear" />
-                      <RakeTaskImpl description="Creates a db/schema_cache.yml file" fullCommand="db:schema:cache:dump" id="dump" />
-                    </subtasks>
-                  </RakeTaskImpl>
-                  <RakeTaskImpl description="Creates a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']` or `config.active_record.schema_format`)" fullCommand="db:schema:dump" id="dump" />
-                  <RakeTaskImpl description="Loads a database schema file (either db/schema.rb or db/structure.sql, depending on `ENV['SCHEMA_FORMAT']` or `config.active_record.schema_format`) into the database" fullCommand="db:schema:load" id="load" />
-                </subtasks>
-              </RakeTaskImpl>
-              <RakeTaskImpl description="Loads the seed data from db/seeds.rb" fullCommand="db:seed" id="seed" />
-              <RakeTaskImpl id="seed">
-                <subtasks>
-                  <RakeTaskImpl description="Truncates tables of each database for current environment and loads the seeds" fullCommand="db:seed:replant" id="replant" />
-                </subtasks>
-              </RakeTaskImpl>
-              <RakeTaskImpl description="Creates all databases, loads all schemas, and initializes with the seed data (use db:reset to also drop all databases first)" fullCommand="db:setup" id="setup" />
-              <RakeTaskImpl description="Retrieves the current schema version number" fullCommand="db:version" id="version" />
               <RakeTaskImpl description="" fullCommand="db:_dump" id="_dump" />
               <RakeTaskImpl description="" fullCommand="db:abort_if_pending_migrations" id="abort_if_pending_migrations" />
               <RakeTaskImpl description="" fullCommand="db:charset" id="charset" />
               <RakeTaskImpl description="" fullCommand="db:check_protected_environments" id="check_protected_environments" />
               <RakeTaskImpl description="" fullCommand="db:collation" id="collation" />
+              <RakeTaskImpl description="" fullCommand="db:create" id="create" />
               <RakeTaskImpl id="create">
                 <subtasks>
                   <RakeTaskImpl description="" fullCommand="db:create:all" id="all" />
                 </subtasks>
               </RakeTaskImpl>
+              <RakeTaskImpl description="" fullCommand="db:drop" id="drop" />
               <RakeTaskImpl id="drop">
                 <subtasks>
                   <RakeTaskImpl description="" fullCommand="db:drop:_unsafe" id="_unsafe" />
                   <RakeTaskImpl description="" fullCommand="db:drop:all" id="all" />
                 </subtasks>
               </RakeTaskImpl>
+              <RakeTaskImpl id="encryption">
+                <subtasks>
+                  <RakeTaskImpl description="" fullCommand="db:encryption:init" id="init" />
+                </subtasks>
+              </RakeTaskImpl>
+              <RakeTaskImpl id="environment">
+                <subtasks>
+                  <RakeTaskImpl description="" fullCommand="db:environment:set" id="set" />
+                </subtasks>
+              </RakeTaskImpl>
+              <RakeTaskImpl id="fixtures">
+                <subtasks>
+                  <RakeTaskImpl description="" fullCommand="db:fixtures:identify" id="identify" />
+                  <RakeTaskImpl description="" fullCommand="db:fixtures:load" id="load" />
+                </subtasks>
+              </RakeTaskImpl>
               <RakeTaskImpl description="" fullCommand="db:forward" id="forward" />
               <RakeTaskImpl description="" fullCommand="db:load_config" id="load_config" />
+              <RakeTaskImpl description="" fullCommand="db:migrate" id="migrate" />
+              <RakeTaskImpl id="migrate">
+                <subtasks>
+                  <RakeTaskImpl description="" fullCommand="db:migrate:down" id="down" />
+                  <RakeTaskImpl description="" fullCommand="db:migrate:redo" id="redo" />
+                  <RakeTaskImpl description="" fullCommand="db:migrate:reset" id="reset" />
+                  <RakeTaskImpl description="" fullCommand="db:migrate:status" id="status" />
+                  <RakeTaskImpl description="" fullCommand="db:migrate:up" id="up" />
+                </subtasks>
+              </RakeTaskImpl>
+              <RakeTaskImpl description="" fullCommand="db:prepare" id="prepare" />
               <RakeTaskImpl description="" fullCommand="db:purge" id="purge" />
               <RakeTaskImpl id="purge">
                 <subtasks>
                   <RakeTaskImpl description="" fullCommand="db:purge:all" id="all" />
                 </subtasks>
               </RakeTaskImpl>
+              <RakeTaskImpl description="" fullCommand="db:reset" id="reset" />
               <RakeTaskImpl id="reset">
                 <subtasks>
                   <RakeTaskImpl description="" fullCommand="db:reset:all" id="all" />
                 </subtasks>
               </RakeTaskImpl>
+              <RakeTaskImpl description="" fullCommand="db:rollback" id="rollback" />
+              <RakeTaskImpl id="schema">
+                <subtasks>
+                  <RakeTaskImpl id="cache">
+                    <subtasks>
+                      <RakeTaskImpl description="" fullCommand="db:schema:cache:clear" id="clear" />
+                      <RakeTaskImpl description="" fullCommand="db:schema:cache:dump" id="dump" />
+                    </subtasks>
+                  </RakeTaskImpl>
+                  <RakeTaskImpl description="" fullCommand="db:schema:dump" id="dump" />
+                  <RakeTaskImpl description="" fullCommand="db:schema:load" id="load" />
+                </subtasks>
+              </RakeTaskImpl>
+              <RakeTaskImpl description="" fullCommand="db:seed" id="seed" />
+              <RakeTaskImpl id="seed">
+                <subtasks>
+                  <RakeTaskImpl description="" fullCommand="db:seed:replant" id="replant" />
+                </subtasks>
+              </RakeTaskImpl>
+              <RakeTaskImpl description="" fullCommand="db:setup" id="setup" />
               <RakeTaskImpl id="setup">
                 <subtasks>
                   <RakeTaskImpl description="" fullCommand="db:setup:all" id="all" />
@@ -860,82 +860,94 @@
                 </subtasks>
               </RakeTaskImpl>
               <RakeTaskImpl description="" fullCommand="db:truncate_all" id="truncate_all" />
+              <RakeTaskImpl description="" fullCommand="db:version" id="version" />
             </subtasks>
           </RakeTaskImpl>
+          <RakeTaskImpl description="" fullCommand="default" id="default" />
+          <RakeTaskImpl description="" fullCommand="environment" id="environment" />
           <RakeTaskImpl id="hotwire">
             <subtasks>
-              <RakeTaskImpl description="Install Hotwire into the app" fullCommand="hotwire:install" id="install" />
+              <RakeTaskImpl description="" fullCommand="hotwire:install" id="install" />
             </subtasks>
           </RakeTaskImpl>
           <RakeTaskImpl id="importmap">
             <subtasks>
-              <RakeTaskImpl description="Setup Importmap for the app" fullCommand="importmap:install" id="install" />
+              <RakeTaskImpl description="" fullCommand="importmap:install" id="install" />
             </subtasks>
           </RakeTaskImpl>
           <RakeTaskImpl id="log">
             <subtasks>
-              <RakeTaskImpl description="Truncates all/specified *.log files in log/ to zero bytes (specify which logs with LOGS=test,development)" fullCommand="log:clear" id="clear" />
+              <RakeTaskImpl description="" fullCommand="log:clear" id="clear" />
             </subtasks>
           </RakeTaskImpl>
-          <RakeTaskImpl description="Prints out your Rack middleware stack" fullCommand="middleware" id="middleware" />
+          <RakeTaskImpl description="" fullCommand="middleware" id="middleware" />
           <RakeTaskImpl id="motor">
             <subtasks>
-              <RakeTaskImpl description="Update configs/motor.yml file" fullCommand="motor:dump" id="dump" />
-              <RakeTaskImpl description="Create migratione and add route" fullCommand="motor:install" id="install" />
-              <RakeTaskImpl description="Load configs from configs/motor.yml file" fullCommand="motor:load" id="load" />
-              <RakeTaskImpl description="Reload configs from configs/motor.yml file" fullCommand="motor:reload" id="reload" />
-              <RakeTaskImpl description="Synchronize configs with remote application" fullCommand="motor:sync" id="sync" />
+              <RakeTaskImpl description="" fullCommand="motor:dump" id="dump" />
+              <RakeTaskImpl description="" fullCommand="motor:install" id="install" />
+              <RakeTaskImpl description="" fullCommand="motor:load" id="load" />
+              <RakeTaskImpl description="" fullCommand="motor:reload" id="reload" />
+              <RakeTaskImpl description="" fullCommand="motor:sync" id="sync" />
             </subtasks>
           </RakeTaskImpl>
-          <RakeTaskImpl description="Remove schema information from model and fixture files" fullCommand="remove_annotation" id="remove_annotation" />
-          <RakeTaskImpl description="Removes the route map from routes.rb" fullCommand="remove_routes" id="remove_routes" />
-          <RakeTaskImpl description="Restart app by touching tmp/restart.txt" fullCommand="restart" id="restart" />
-          <RakeTaskImpl description="Generate a cryptographically secure secret key (this is typically used to generate a secret for cookie sessions)" fullCommand="secret" id="secret" />
-          <RakeTaskImpl description="Run all specs in spec directory (excluding plugin specs)" fullCommand="spec" id="spec" />
+          <RakeTaskImpl id="railties">
+            <subtasks>
+              <RakeTaskImpl id="install">
+                <subtasks>
+                  <RakeTaskImpl description="" fullCommand="railties:install:migrations" id="migrations" />
+                </subtasks>
+              </RakeTaskImpl>
+            </subtasks>
+          </RakeTaskImpl>
+          <RakeTaskImpl description="" fullCommand="remove_annotation" id="remove_annotation" />
+          <RakeTaskImpl description="" fullCommand="remove_routes" id="remove_routes" />
+          <RakeTaskImpl description="" fullCommand="restart" id="restart" />
+          <RakeTaskImpl description="" fullCommand="secret" id="secret" />
+          <RakeTaskImpl description="" fullCommand="set_annotation_options" id="set_annotation_options" />
+          <RakeTaskImpl description="" fullCommand="spec" id="spec" />
           <RakeTaskImpl id="spec">
             <subtasks>
-              <RakeTaskImpl description="Run the code examples in spec/helpers" fullCommand="spec:helpers" id="helpers" />
-              <RakeTaskImpl description="Run the code examples in spec/model" fullCommand="spec:model" id="model" />
-              <RakeTaskImpl description="Run the code examples in spec/requests" fullCommand="spec:requests" id="requests" />
+              <RakeTaskImpl description="" fullCommand="spec:helpers" id="helpers" />
+              <RakeTaskImpl description="" fullCommand="spec:model" id="model" />
               <RakeTaskImpl description="" fullCommand="spec:prepare" id="prepare" />
+              <RakeTaskImpl description="" fullCommand="spec:requests" id="requests" />
               <RakeTaskImpl description="" fullCommand="spec:statsetup" id="statsetup" />
             </subtasks>
           </RakeTaskImpl>
-          <RakeTaskImpl description="Report code statistics (KLOCs, etc) from the application or engine" fullCommand="stats" id="stats" />
+          <RakeTaskImpl description="" fullCommand="stats" id="stats" />
           <RakeTaskImpl id="stimulus">
             <subtasks>
-              <RakeTaskImpl description="Install Stimulus into the app" fullCommand="stimulus:install" id="install" />
+              <RakeTaskImpl description="" fullCommand="stimulus:install" id="install" />
               <RakeTaskImpl id="install">
                 <subtasks>
-                  <RakeTaskImpl description="Install Stimulus on an app running bun" fullCommand="stimulus:install:bun" id="bun" />
-                  <RakeTaskImpl description="Install Stimulus on an app running importmap-rails" fullCommand="stimulus:install:importmap" id="importmap" />
-                  <RakeTaskImpl description="Install Stimulus on an app running node" fullCommand="stimulus:install:node" id="node" />
+                  <RakeTaskImpl description="" fullCommand="stimulus:install:bun" id="bun" />
+                  <RakeTaskImpl description="" fullCommand="stimulus:install:importmap" id="importmap" />
+                  <RakeTaskImpl description="" fullCommand="stimulus:install:node" id="node" />
                 </subtasks>
               </RakeTaskImpl>
               <RakeTaskImpl id="manifest">
                 <subtasks>
-                  <RakeTaskImpl description="Show the current Stimulus manifest (all installed controllers)" fullCommand="stimulus:manifest:display" id="display" />
-                  <RakeTaskImpl description="Update the Stimulus manifest (will overwrite controllers/index.js)" fullCommand="stimulus:manifest:update" id="update" />
+                  <RakeTaskImpl description="" fullCommand="stimulus:manifest:display" id="display" />
+                  <RakeTaskImpl description="" fullCommand="stimulus:manifest:update" id="update" />
                 </subtasks>
               </RakeTaskImpl>
             </subtasks>
           </RakeTaskImpl>
           <RakeTaskImpl id="tailwindcss">
             <subtasks>
-              <RakeTaskImpl description="Build your Tailwind CSS" fullCommand="tailwindcss:build" id="build" />
-              <RakeTaskImpl description="Remove CSS builds" fullCommand="tailwindcss:clobber" id="clobber" />
-              <RakeTaskImpl description="Install Tailwind CSS into the app" fullCommand="tailwindcss:install" id="install" />
-              <RakeTaskImpl description="Watch and build your Tailwind CSS on file changes" fullCommand="tailwindcss:watch" id="watch" />
+              <RakeTaskImpl description="" fullCommand="tailwindcss:build" id="build" />
+              <RakeTaskImpl description="" fullCommand="tailwindcss:clobber" id="clobber" />
+              <RakeTaskImpl description="" fullCommand="tailwindcss:install" id="install" />
+              <RakeTaskImpl description="" fullCommand="tailwindcss:watch" id="watch" />
             </subtasks>
           </RakeTaskImpl>
-          <RakeTaskImpl description="Runs all tests in test folder except system ones" fullCommand="test" id="test" />
+          <RakeTaskImpl description="" fullCommand="test" id="test" />
           <RakeTaskImpl id="test">
             <subtasks>
-              <RakeTaskImpl description="Runs all tests, including system tests" fullCommand="test:all" id="all" />
-              <RakeTaskImpl description="Run tests quickly, but also reset db" fullCommand="test:db" id="db" />
-              <RakeTaskImpl description="Run system tests only" fullCommand="test:system" id="system" />
+              <RakeTaskImpl description="" fullCommand="test:all" id="all" />
               <RakeTaskImpl description="" fullCommand="test:channels" id="channels" />
               <RakeTaskImpl description="" fullCommand="test:controllers" id="controllers" />
+              <RakeTaskImpl description="" fullCommand="test:db" id="db" />
               <RakeTaskImpl description="" fullCommand="test:functionals" id="functionals" />
               <RakeTaskImpl description="" fullCommand="test:generators" id="generators" />
               <RakeTaskImpl description="" fullCommand="test:helpers" id="helpers" />
@@ -946,12 +958,12 @@
               <RakeTaskImpl description="" fullCommand="test:models" id="models" />
               <RakeTaskImpl description="" fullCommand="test:prepare" id="prepare" />
               <RakeTaskImpl description="" fullCommand="test:run" id="run" />
+              <RakeTaskImpl description="" fullCommand="test:system" id="system" />
               <RakeTaskImpl description="" fullCommand="test:units" id="units" />
             </subtasks>
           </RakeTaskImpl>
           <RakeTaskImpl id="time">
             <subtasks>
-              <RakeTaskImpl description="List all time zones, list by two-letter country code (`bin/rails time:zones[US]`), or list by UTC offset (`bin/rails time:zones[-8]`)" fullCommand="time:zones[country_or_offset]" id="zones[country_or_offset]" />
               <RakeTaskImpl description="" fullCommand="time:zones" id="zones" />
               <RakeTaskImpl id="zones">
                 <subtasks>
@@ -962,15 +974,20 @@
               </RakeTaskImpl>
             </subtasks>
           </RakeTaskImpl>
+          <RakeTaskImpl description="" fullCommand="tmp" id="tmp" />
+          <RakeTaskImpl description="" fullCommand="tmp/cache" id="tmp/cache" />
+          <RakeTaskImpl description="" fullCommand="tmp/cache/assets" id="tmp/cache/assets" />
+          <RakeTaskImpl description="" fullCommand="tmp/pids" id="tmp/pids" />
+          <RakeTaskImpl description="" fullCommand="tmp/sockets" id="tmp/sockets" />
           <RakeTaskImpl id="tmp">
             <subtasks>
-              <RakeTaskImpl description="Clear cache, socket and screenshot files from tmp/ (narrow w/ tmp:cache:clear, tmp:sockets:clear, tmp:screenshots:clear)" fullCommand="tmp:clear" id="clear" />
-              <RakeTaskImpl description="Creates tmp directories for cache, sockets, and pids" fullCommand="tmp:create" id="create" />
               <RakeTaskImpl id="cache">
                 <subtasks>
                   <RakeTaskImpl description="" fullCommand="tmp:cache:clear" id="clear" />
                 </subtasks>
               </RakeTaskImpl>
+              <RakeTaskImpl description="" fullCommand="tmp:clear" id="clear" />
+              <RakeTaskImpl description="" fullCommand="tmp:create" id="create" />
               <RakeTaskImpl id="pids">
                 <subtasks>
                   <RakeTaskImpl description="" fullCommand="tmp:pids:clear" id="clear" />
@@ -995,44 +1012,26 @@
           </RakeTaskImpl>
           <RakeTaskImpl id="turbo">
             <subtasks>
-              <RakeTaskImpl description="Install Turbo into the app" fullCommand="turbo:install" id="install" />
+              <RakeTaskImpl description="" fullCommand="turbo:install" id="install" />
               <RakeTaskImpl id="install">
                 <subtasks>
-                  <RakeTaskImpl description="Install Turbo into the app with bun" fullCommand="turbo:install:bun" id="bun" />
-                  <RakeTaskImpl description="Install Turbo into the app with asset pipeline" fullCommand="turbo:install:importmap" id="importmap" />
-                  <RakeTaskImpl description="Install Turbo into the app with webpacker" fullCommand="turbo:install:node" id="node" />
-                  <RakeTaskImpl description="Switch on Redis and use it in development" fullCommand="turbo:install:redis" id="redis" />
+                  <RakeTaskImpl description="" fullCommand="turbo:install:bun" id="bun" />
+                  <RakeTaskImpl description="" fullCommand="turbo:install:importmap" id="importmap" />
+                  <RakeTaskImpl description="" fullCommand="turbo:install:node" id="node" />
                 </subtasks>
               </RakeTaskImpl>
             </subtasks>
           </RakeTaskImpl>
           <RakeTaskImpl id="yarn">
             <subtasks>
-              <RakeTaskImpl description="Install all JavaScript dependencies as specified via Yarn" fullCommand="yarn:install" id="install" />
+              <RakeTaskImpl description="" fullCommand="yarn:install" id="install" />
             </subtasks>
           </RakeTaskImpl>
           <RakeTaskImpl id="zeitwerk">
             <subtasks>
-              <RakeTaskImpl description="Checks project structure for Zeitwerk compatibility" fullCommand="zeitwerk:check" id="check" />
+              <RakeTaskImpl description="" fullCommand="zeitwerk:check" id="check" />
             </subtasks>
           </RakeTaskImpl>
-          <RakeTaskImpl description="" fullCommand="default" id="default" />
-          <RakeTaskImpl description="" fullCommand="environment" id="environment" />
-          <RakeTaskImpl id="railties">
-            <subtasks>
-              <RakeTaskImpl id="install">
-                <subtasks>
-                  <RakeTaskImpl description="" fullCommand="railties:install:migrations" id="migrations" />
-                </subtasks>
-              </RakeTaskImpl>
-            </subtasks>
-          </RakeTaskImpl>
-          <RakeTaskImpl description="" fullCommand="set_annotation_options" id="set_annotation_options" />
-          <RakeTaskImpl description="" fullCommand="tmp" id="tmp" />
-          <RakeTaskImpl description="" fullCommand="tmp/cache" id="tmp/cache" />
-          <RakeTaskImpl description="" fullCommand="tmp/cache/assets" id="tmp/cache/assets" />
-          <RakeTaskImpl description="" fullCommand="tmp/pids" id="tmp/pids" />
-          <RakeTaskImpl description="" fullCommand="tmp/sockets" id="tmp/sockets" />
         </subtasks>
       </RakeTaskImpl>
     </option>

--- a/Gemfile
+++ b/Gemfile
@@ -90,4 +90,7 @@ gem 'sentry-ruby'
 gem 'stackprof'
 gem 'tailwindcss-rails', '~> 2.0'
 
+gem 'base64'
 gem 'bullet', '~> 7.2'
+gem 'mutex_m'
+gem 'ostruct'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       activerecord (>= 5.2, < 8.2)
       activesupport (>= 5.2, < 8.2)
     aws_cf_signer (0.1.3)
+    base64 (0.2.0)
     bcrypt (3.1.20)
     bigdecimal (3.1.8)
     bindex (0.8.1)
@@ -193,6 +194,7 @@ GEM
       fugit (~> 1.0)
       rails (>= 5.2)
     msgpack (1.7.5)
+    mutex_m (0.2.0)
     net-imap (0.5.1)
       date
       net-protocol
@@ -217,6 +219,7 @@ GEM
     nokogiri (1.16.8-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    ostruct (0.6.1)
     pagy (6.5.0)
     parallel (1.26.3)
     parser (3.3.6.0)
@@ -394,6 +397,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate (~> 3.2)
+  base64
   bootsnap
   bullet (~> 7.2)
   cancancan
@@ -411,6 +415,8 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   motor-admin
+  mutex_m
+  ostruct
   pagy (~> 6.0)
   pg (~> 1.1)
   puma (~> 5.0)

--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -27,7 +27,7 @@ class NewsController < ApplicationController
 
   def show
     @news = News.includes(image_attachment: :blob).find(params[:id])
-    @similar_news = News.includes(image_attachment: :blob).where(type_of_news: @news.type_of_news).where.not(id: @news.id).limit(3)
+    @similar_news = News.includes(image_attachment: :blob).where(type_of_news: @news.type_of_news).where.not(id: @news.id).limit(5)
   end
 
   def new

--- a/app/controllers/opponent_controller.rb
+++ b/app/controllers/opponent_controller.rb
@@ -71,6 +71,6 @@ class OpponentController < ApplicationController
 
   def opponent_params
     params.require(:opponent).permit(:match_date, :match_time, :venue, :tournament, :score_one, :score_two, :user_id,
-                                     :opponent_team_id)
+                                     :opponent_team_id, :season_id)
   end
 end

--- a/app/models/opponent.rb
+++ b/app/models/opponent.rb
@@ -31,6 +31,7 @@ class Opponent < ApplicationRecord
   belongs_to :user, class_name: 'User', optional: true
   belongs_to :opponent_team
   before_validation :capitalize
+  belongs_to :season
   has_many :scorers, foreign_key: :opponent_id, class_name: 'Scorer', dependent: :destroy
   # validates :match_date, :match_time, :tournament, :venue, presence: true
 

--- a/app/models/season.rb
+++ b/app/models/season.rb
@@ -21,5 +21,6 @@
 class Season < ApplicationRecord
   belongs_to :user
   has_many :statistics, foreign_key: :season_id, dependent: :destroy
+  has_many :opponents, foreign_key: :season_id, dependent: :nullify
   validates :name, presence: true, uniqueness: true
 end

--- a/app/views/news/_similar_news.html.erb
+++ b/app/views/news/_similar_news.html.erb
@@ -1,8 +1,8 @@
 <article class="flex justify-start mt-4">
-  <% @similar_news.limit(3).each do |similar_news| %>
-    <div class="bg-black shadow-lg overflow-hidden w-1/3 mr-2">
+  <% @similar_news.limit(4).each do |similar_news| %>
+    <div class="bg-black shadow-lg overflow-hidden w-1/4 mr-2">
       <%= link_to news_path(similar_news) do %>
-        <%= image_tag(similar_news.image, class: "rounded w-full h-[150px]") %>
+        <%= image_tag(similar_news.image, class: "rounded w-full h-[200px]") %>
         <div class="flex">
           <div class="text-left">
             <a href="#" class="mt-4 inline-flex text-sm items-center text-black bg-[#FAE115] p-1 rounded ">

--- a/app/views/news/edit.html.erb
+++ b/app/views/news/edit.html.erb
@@ -1,4 +1,4 @@
-<div class="max-w-4xl mx-auto my-8 text-black">
+<div class="max-w-4xl mx-auto my-8">
   <%= form_with(model: @news, url: news_path(@news), method: :patch, class: "bg-white rounded shadow-md p-6") do |form| %>
 
     <div class="mb-4 flex">

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -41,11 +41,12 @@
               </a>
             </div>
           </div>
-
         </div>
-        <%= render 'news/similar_news' %>
-      </div>
 
+        <%= render 'news/similar_news' %>
+
+
+      </div>
       <div class="col-span-1">
       </div>
     </div>

--- a/app/views/opponent/_schedule.html.erb
+++ b/app/views/opponent/_schedule.html.erb
@@ -35,7 +35,7 @@
           <div class="col-span-2 text-center">
             <div class="text-gray-500 uppercase">
               <% if opp.blank? %>
-                <%#= opp.match_date.strftime("%a %d  %b") %>
+                <%= opp.match_date.strftime("%a %d  %b") %>
               <% end %>
             </div>
             <div class="font-bold"><%= opp.match_time.strftime("%I:%M") %></div>

--- a/app/views/opponent/edit.html.erb
+++ b/app/views/opponent/edit.html.erb
@@ -17,11 +17,11 @@
       </div>
       <div class="flex  justify-between">
 
-        <%= f.text_field :venue, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] border-black focus:outline-none" ,placeholder: "Venue" %>
-        <%= f.text_field :tournament, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] border-black focus:outline-none" ,placeholder: "Tournament" %>
+        <%= f.text_field :venue, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] border-black focus:outline-none" ,placeholder: "Venue"  , required: true %>
+        <%= f.text_field :tournament, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] border-black focus:outline-none" ,placeholder: "Tournament"  , required: true %>
       </div>
       <div class="flex  justify-between gap-3">
-        <%= f.collection_select :opponent_team_id, OpponentTeam.all, :id, :name, {prompt: "Select Opponent Team"}, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] border-black focus:outline-none" %>
+        <%= f.collection_select :opponent_team_id, OpponentTeam.all, :id, :name, {prompt: "Select Opponent Team"}, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] border-black focus:outline-none"  , required: true %>
         <%= f.number_field :score_one, class: "h-[50px] flex items-center p-2 w-[30%] border-b bg-[#F7F3ED] border-black focus:outline-none" ,placeholder: "Home Team Score" %>
         <%= f.number_field  :score_two, class: "h-[50px] flex items-center p-2 w-[30%] border-b bg-[#F7F3ED] border-black focus:outline-none" ,placeholder: "Away Team Score" %>
 

--- a/app/views/opponent/index.html.erb
+++ b/app/views/opponent/index.html.erb
@@ -64,11 +64,11 @@
   </div>
 
   <div id="Schedule" class="tabcontent active  ">
-    <%#= render 'opponent/schedule' %>
+    <%= render 'opponent/schedule' %>
   </div>
 
   <div id="Result" class="tabcontent">
-    <%#= render 'opponent/results' %>
+    <%= render 'opponent/results' %>
   </div>
   <!--Fixtures-->
   <div id="Fixtures" class="tabcontent">

--- a/app/views/opponent/new.html.erb
+++ b/app/views/opponent/new.html.erb
@@ -21,6 +21,11 @@
         <%= f.text_field :venue, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Venue"  , required: true%>
         <%= f.text_field :tournament, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Tournament" , required: true %>
       </div>
+      <!-- Add season to the form -->
+      <div class="flex  justify-between">
+        <%= f.collection_select :season_id, Season.all, :id, :name, {prompt: "Select Season"}, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none"  , required: true %>
+      </div>
+
       <div class="flex  justify-between gap-3">
         <%= f.collection_select :opponent_team_id, OpponentTeam.all, :id, :name, {prompt: "Select Opponent Team"}, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none"  , required: true %>
         <%= f.number_field :score_one, class: "h-[50px] flex items-center p-2 w-[30%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Home Team Score" %>

--- a/app/views/opponent/new.html.erb
+++ b/app/views/opponent/new.html.erb
@@ -18,11 +18,11 @@
       </div>
       <div class="flex  justify-between">
 
-        <%= f.text_field :venue, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Venue" %>
-        <%= f.text_field :tournament, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Tournament" %>
+        <%= f.text_field :venue, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Venue"  , required: true%>
+        <%= f.text_field :tournament, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Tournament" , required: true %>
       </div>
       <div class="flex  justify-between gap-3">
-        <%= f.collection_select :opponent_team_id, OpponentTeam.all, :id, :name, {prompt: "Select Opponent Team"}, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" %>
+        <%= f.collection_select :opponent_team_id, OpponentTeam.all, :id, :name, {prompt: "Select Opponent Team"}, class: "h-[50px] flex items-center p-2 w-[45%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none"  , required: true %>
         <%= f.number_field :score_one, class: "h-[50px] flex items-center p-2 w-[30%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Home Team Score" %>
         <%= f.number_field  :score_two, class: "h-[50px] flex items-center p-2 w-[30%] border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Away Team Score" %>
 


### PR DESCRIPTION
Reverts ger619/mseal-rails#124
This pull request includes several changes to the `news` feature, primarily focusing on enhancing the display and functionality of similar news articles and improving the layout of the news views. The most important changes are summarized below:

Enhancements to similar news functionality:

* [`app/controllers/news_controller.rb`](diffhunk://#diff-94d1bfe7692f0a221f1b1b25e2a58727a0e3eb61e52760f37087f2220867ea2fL30-R30): Increased the limit of similar news articles displayed from 3 to 5.
* [`app/views/news/_similar_news.html.erb`](diffhunk://#diff-d887a95183ab78be69d0c1e43bd2e9e216d8ce10536fe1d5f39579b0032bcb0eL2-R5): Adjusted the limit to 4 for the display of similar news articles and updated the layout to use a quarter-width column. Also increased the image height from 150px to 200px.

Layout improvements:

* [`app/views/news/edit.html.erb`](diffhunk://#diff-fa43fe996231a1e16e8a9d2ebdf44223b962e92ebe9f49dcf34df2191af872adL1-R1): Removed redundant `text-black` class from the main container div.
* [`app/views/news/show.html.erb`](diffhunk://#diff-ff7bcff9f6d9e50eb95fa219808e093d609787bd173f6e9c055e9a9564cccf28L44-R49): Added spacing adjustments and ensured the similar news partial is rendered correctly within the layout.