### PR TITLE
Enable rendering of opponent schedule and results

### DIFF
--- a/app/views/opponent/_schedule.html.erb
+++ b/app/views/opponent/_schedule.html.erb
@@ -34,11 +34,11 @@
         <% @opponent2.each do |opp| %>
           <div class="col-span-2 text-center">
             <div class="text-gray-500 uppercase">
-              <% if opp.blank? %>
-                <%#= opp.match_date.strftime("%a %d  %b") %>
-              <% end %>
+                <%= opp.match_date.strftime("%a %d  %b") %>
             </div>
-            <div class="font-bold"><%= opp.match_time.strftime("%I:%M") %></div>
+            <div class="font-bold">
+              <%= opp.match_time.strftime("%I:%M") %>
+            </div>
           </div>
           <div class="col-span-3 flex items-center space-x-2">
             <%= image_tag('kpl.png', class: 'h-12', alt: 'Competition Logo') %>

--- a/app/views/opponent/index.html.erb
+++ b/app/views/opponent/index.html.erb
@@ -64,11 +64,11 @@
   </div>
 
   <div id="Schedule" class="tabcontent active  ">
-    <%#= render 'opponent/schedule' %>
+    <%= render 'opponent/schedule' %>
   </div>
 
   <div id="Result" class="tabcontent">
-    <%#= render 'opponent/results' %>
+    <%= render 'opponent/results' %>
   </div>
   <!--Fixtures-->
   <div id="Fixtures" class="tabcontent">

--- a/app/views/opponent/new.html.erb
+++ b/app/views/opponent/new.html.erb
@@ -28,8 +28,6 @@
 
       </div>
 
-
-
       <%= f.submit "Submit", class: "w-[300px] mt-10 mb-10 md:mb-10 md:mt-16  mx-auto p-4 bg-[#F4E721] text-3xl text-black uppercase" %>
     </div>
 


### PR DESCRIPTION
Uncommented and activated partials for opponent schedule and results on the index view. Fixed rendering of match date and time in the schedule partial to display correctly. Removed redundant blank lines in the new opponent form for cleaner code structure.