### PR TITLE
Remove all N+1 errors

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,15 +2,16 @@ class Ability
   include CanCan::Ability
   def initialize(user)
     user ||= User.new
+
+    if user.role == 'admin'
+      can :manage, :all
+    else
+      can :read, :all
+    end
     can :read, [Advert, Club, HallOfFame, News, Opponent, OpponentTeam, Product, Team, Statistic, Season, Scorer]
-    cannot :manage, Motor::Admin
 
     return unless user.role == 'moderator'
 
     can :manage, [Advert, Club, HallOfFame, News, Opponent, OpponentTeam, Product, Team, Statistic, Season, Scorer]
-
-    return unless user.role == 'admin'
-
-    can :manage, :all
   end
 end

--- a/app/views/home/_player_section.html.erb
+++ b/app/views/home/_player_section.html.erb
@@ -11,7 +11,7 @@
       <div class="relative">
         <div id="carousel" class="flex space-x-4 sm:space-x-6 overflow-x-auto snap-x snap-mandatory scrollbar-hide">
           <!-- Player Cards -->
-          <% @teams.limit(5).each do |team| %>
+          <% @teams.select { |team| team.active }.take(5).each do |team| %>
             <div class="carousel-item flex-shrink-0 w-2/3 sm:w-1/3 snap-center">
               <div class="rounded-md overflow-hidden">
                 <% if team.image.attached? %>

--- a/app/views/product/_production.html.erb
+++ b/app/views/product/_production.html.erb
@@ -54,6 +54,7 @@
         <div class="bg-transparent border border-gray-300 rounded shadow overflow-hidden">
           <div class="relative">
             <img src="./assets/jersey-full.png" alt="Rounded Red Hat" class="w-full h-64 object-cover">
+            <%= image_tag(@product.photo_product) %>
             <button class="absolute bottom-4 right-4 bg-yellow-400 text-black p-2 rounded-full shadow hover:bg-yellow-500">
               <svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16" class="w-5 h-5">
                 <path d="M0 1.5A.5.5 0 0 1 .5 1h1a.5.5 0 0 1 .485.379L2.89 5H14.5a.5.5 0 0 1 .49.598l-1.5 8A.5.5 0 0 1 13 14H4a.5.5 0 0 1-.49-.402L.61 1.607.5 1H.5zM5 12a2 2 0 1 0 4 0H5z"/>

--- a/app/views/product/new.html.erb
+++ b/app/views/product/new.html.erb
@@ -15,7 +15,7 @@
 
       </div>
       <div class="flex justify-between">
-        <%= f.file_field :photo_product, class: "h-[50px] w-[45%] bg-[#F7F3ED] p-2 border-black focus:outline-none" ,placeholder: "Upload Photo", :required => :true%>
+        <%= f.file_field :photo_product, class: "h-[50px] w-[45%] bg-[#F7F3ED] p-2 border-black focus:outline-none" ,placeholder: "Upload Photo", :required => :true %>
       </div>
 
       <%= f.rich_text_area :content, class: "bg-[#F7F3ED] w-[100%] p-2 border-b border-black focus:outline-none", row: "12" ,placeholder: "Product Description  *", :required => :true%>

--- a/app/views/team/show.html.erb
+++ b/app/views/team/show.html.erb
@@ -26,7 +26,7 @@
       <p class="text-sm sm:text-base font-light"><%= @team.content %></p>
     </div>
     <div class="flex flex-col sm:flex-row gap-2">
-      <% if current_user && current_user.role === 'moderator' %>
+      <% if current_user&.role == 'moderator' || current_user&.role == 'admin' %>
         <%= link_to "Edit", edit_team_path(@team.id), class: "bg-[#FAE115] p-3 rounded-lg mt-2 uppercase" %>
         <%= button_to 'Destroy', @team, method: :delete, data: { confirm: 'Are you sure?' }, class: "bg-[#FAE115] p-3 rounded-lg mt-2 uppercase" %>
       <% end %>


### PR DESCRIPTION
This pull request includes several changes to improve user permissions, update views, and enhance product display functionality. The most important changes are grouped into two themes: user permissions and view updates.

### User Permissions:

* [`app/models/ability.rb`](diffhunk://#diff-0fdc2ce2595c4fe479d6a97b404013651e8a0e2d4b02d93c87843b3a30103d9fR5-L14): Adjusted the `Ability` class to grant `admin` users full management permissions and restrict other users to read-only access. This change also ensures that `moderator` users can manage specific resources.

### View Updates:

* [`app/views/home/_player_section.html.erb`](diffhunk://#diff-c2cad425132816b40e76d8bebf30117cc5a601e47d2d52c9877cbb2e303e103aL14-R14): Updated the player section to display only active teams, ensuring that inactive teams are excluded from the carousel.
* [`app/views/product/_production.html.erb`](diffhunk://#diff-9fd5c866033235673d4f9dd3d725cefdea8465488701342116aabe85101f19beR57): Added a product image tag to display the product photo dynamically, enhancing the visual presentation of products.
* [`app/views/team/show.html.erb`](diffhunk://#diff-f6fccb204c12c3ed35a3df9b14e1c1425324e23640233b57e6696f1b749b6dcfL29-R29): Modified the team show view to allow both `admin` and `moderator` users to edit and destroy team records, increasing administrative flexibility.