### PR TITLE
Fixing main menu to be fixed

### DIFF
--- a/app/views/news/edit.html.erb
+++ b/app/views/news/edit.html.erb
@@ -3,25 +3,25 @@
 
     <div class="mb-4 flex">
       <%= image_tag form.object.image, class: 'w-72' if form.object.image.present? %>
-      <%= form.file_field :image, class: "appearance-none border rounded w-full h-1/2 py-2 px-3 leading-tight focus:outline-none focus:shadow-outline", placeholder: "All Photos on the site must be landscape" %>
+      <%= form.file_field :image, class: "appearance-none border rounded w-full h-1/2 text-black py-2 px-3 leading-tight focus:outline-none focus:shadow-outline", placeholder: "All Photos on the site must be landscape" %>
     </div>
 
     <div class="flex justify-center gap-2">
 
         <div class="mb-4 w-full">
-          <%= form.label :header_news, class: "block text-sm font-bold mb-2" %>
-          <%= form.text_field :header_news, class: "appearance-none border rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline" %>
+          <%= form.label :header_news, class: "block text-sm font-bold mb-2  text-black" %>
+          <%= form.text_field :header_news, class: "appearance-none border rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline  text-black" %>
         </div>
         <div class="mb-4 w-full">
-          <%= form.label :type_of_news, class: "block text-sm font-bold mb-2" %>
+          <%= form.label :type_of_news, class: "block text-sm font-bold mb-2  text-black" %>
           <%= form.select :type_of_news, %w[Injuries News Fans League Latest News Club News Features, prompt: 'Type of News',], prompt: 'Type of News', class: "h-[50px] flex items-center p-2 w-full border-b bg-[#F7F3ED] text-black border-black focus:outline-none" ,placeholder: "Type of News", required: true%>
 
         </div>
     </div>
 
     <div class="mb-6">
-      <%= form.label :content , class: "block text-sm font-bold mb-2" %>
-      <%= form.rich_text_area :content, class: "bg-white h-[500px] appearance-none border rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline" %>
+      <%= form.label :content , class: "block text-sm font-bold mb-2  text-black" %>
+      <%= form.rich_text_area :content, class: "bg-white h-[500px] text-black appearance-none border rounded w-full py-2 px-3 leading-tight focus:outline-none focus:shadow-outline" %>
 
     </div>
 

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -18,15 +18,15 @@
           <%= @news.content %>
         </p>
 
-        <% if current_user && current_user.role == 'moderator' %>
-          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 p-2">
-            <div class="bg-yellow-400 mt-2 p-2 rounded-lg">
-              <%= link_to "Edit", edit_news_path(@news.id), class: "w-full text-black text-sm sm:text-xs md:text-sm lg:text-base font-semibold py-1 px-2 rounded" %>
+        <% if current_user&.role == 'moderator' || current_user&.role == 'admin' %>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 p-2">
+              <div class="bg-yellow-400 mt-2 p-2 rounded-lg">
+                <%= link_to "Edit", edit_news_path(@news.id), class: "w-full text-black text-sm sm:text-xs md:text-sm lg:text-base font-semibold py-1 px-2 rounded" %>
+              </div>
+              <div class="bg-yellow-400 mt-2 p-2 rounded-lg">
+                <%= button_to "Delete", @news, method: :delete, data: { turbo_method: :delete }, class: "w-full text-black font-semibold" %>
+              </div>
             </div>
-            <div class="bg-yellow-400 mt-2 p-2 rounded-lg">
-              <%= button_to "Delete", @news, method: :delete, data: { turbo_method: :delete }, class: "w-full text-black font-semibold" %>
-            </div>
-          </div>
         <% end %>
         <div class="my-10">
           <div class="flex flex-col sm:flex-row items-center space-y-4 sm:space-y-0 sm:space-x-8">


### PR DESCRIPTION
This pull request includes changes to the `app/views/news` directory to enhance the user interface and modify access control for editing news content. The most important changes include updating the styling of form elements and adjusting the conditions for displaying the edit link based on user roles.

Styling updates:

* [`app/views/news/edit.html.erb`](diffhunk://#diff-fa43fe996231a1e16e8a9d2ebdf44223b962e92ebe9f49dcf34df2191af872adL6-R24): Added `text-black` class to various form elements to ensure text is displayed in black color.

Access control adjustments:

* [`app/views/news/show.html.erb`](diffhunk://#diff-ff7bcff9f6d9e50eb95fa219808e093d609787bd173f6e9c055e9a9564cccf28L21-R21): Modified the condition to display the edit link for users with either 'moderator' or 'admin' roles.